### PR TITLE
Use the timestamp of the scrobble.

### DIFF
--- a/lib/party.js
+++ b/lib/party.js
@@ -5,7 +5,6 @@ var Party = exports.Party = function(lastfm, host) {
     EventEmitter.call(this);
 
     var that = this,
-        nowPlayingStartTime,
         stream;
 
     startParty();
@@ -73,7 +72,6 @@ var Party = exports.Party = function(lastfm, host) {
 
     function setCurrentTrack(track) {
         that.nowPlaying = track;
-        nowPlayingStartTime = millisecondsToSeconds((new Date).getTime());
     }
 
     function getTrackDuration(track, callback) {
@@ -92,14 +90,14 @@ var Party = exports.Party = function(lastfm, host) {
 
     function hostScrobbled(track) {
         addRecentPlay(track);
-        copyScrobbleToAllGuests(track, nowPlayingStartTime || millisecondsToSeconds((new Date).getTime()));
+        copyScrobbleToAllGuests(track);
     }
 
-    function copyScrobbleToAllGuests(track, timestamp) {
+    function copyScrobbleToAllGuests(track) {
         _(that.guests).each(function(guest) {
             updateGuest("scrobble", guest, {
                 track: track,
-                timestamp: timestamp
+                timestamp: track.date.uts
             });
         });
     }


### PR DESCRIPTION
Use the timestamp of the scrobble rather than the current time of the boxsocialfm.com server, when it first noticed the track was playing, when scrobbling to the rest of the party.
